### PR TITLE
Add authordate and subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Example:
 ```
 $ gas
 fork-stretchr-testify/
-  master               ↑  origin/master
-  base                    <none>
+  master               ↑  origin/master    15 minutes ago Add new assertion
+  base                    <none>              7 hours ago Fix test
 gs/
-  master               ↑↓ origin/master
+  master               ↑↓ origin/master      3 months ago Release version 2.1.0
 helloworld/
-  push-with-request       <none>
-  add-vcr-2           M   origin/add-vcr-2
-  add-vcr              ↑↓ origin/add-vcr
+  push-with-request       <none>             23 hours ago Add push with request
+  add-vcr-2           M   origin/add-vcr-2  12 months ago Add vcr
+  add-vcr              ↑↓ origin/add-vcr    12 months ago Add vcr
 ```

--- a/main.go
+++ b/main.go
@@ -96,7 +96,12 @@ func run(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) int
 
 			authorDate := color.HiGreenString("%*s", authorDateWidth, b.authorDate)
 
-			fmt.Fprintf(stdout, "  %-*s %s %-*s %s %s\n", nameWidth, b.name, icons, upstreamWidth, upstream, authorDate, b.commitMessageSubject)
+			commitMessageSubject := b.commitMessageSubject
+			if len(commitMessageSubject) > 50 {
+				commitMessageSubject = commitMessageSubject[:50]
+			}
+
+			fmt.Fprintf(stdout, "  %-*s %s %-*s %s %s\n", nameWidth, b.name, icons, upstreamWidth, upstream, authorDate, commitMessageSubject)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -235,7 +235,7 @@ func getBranches(path string) ([]branch, error) {
 	lines := strings.Split(outStr, "\n")
 	branches := make([]branch, len(lines))
 	for i, l := range lines {
-		f := strings.Split(l, ":")
+		f := strings.SplitN(l, ":", 6)
 		branches[i] = branch{
 			head:                 f[0] == "*",
 			dirty:                f[0] == "*" && dirty,

--- a/main_test.go
+++ b/main_test.go
@@ -232,7 +232,7 @@ func TestRemoteNotPushedOtherBranch(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  branch1     <none>        0 seconds ago Add more files
+  branch1     <none> 0 seconds ago Add more files
 `)
 }
 
@@ -273,7 +273,7 @@ func TestRemoteNotPulledBranch(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  branch1     <none>        0 seconds ago Add file 3
+  branch1     <none> 0 seconds ago Add file 3
 `)
 }
 
@@ -334,8 +334,8 @@ func TestMultipleRepos(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `repo1/
-  branch1     <none>        0 seconds ago Add more files
+  branch1     <none> 0 seconds ago Add more files
 repo2/
-  branch1     <none>        0 seconds ago Add more files
+  branch1     <none> 0 seconds ago Add more files
 `)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -28,7 +28,7 @@ func TestNoRemote(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master     <none>
+  master     <none>  
 `)
 }
 
@@ -46,7 +46,7 @@ func TestNoRemoteUntrackedFiles(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master M   <none>
+  master M   <none>  
 `)
 }
 
@@ -65,7 +65,7 @@ func TestNoRemoteStagedFiles(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master M   <none>
+  master M   <none>  
 `)
 }
 
@@ -85,7 +85,7 @@ func TestNoRemoteCommitted(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master     <none>
+  master     <none> 0 seconds ago Add files
 `)
 }
 
@@ -138,7 +138,7 @@ func TestRemoteUntracked(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master M   origin/master
+  master M   origin/master 0 seconds ago Add files
 `)
 }
 
@@ -167,7 +167,7 @@ func TestRemoteStaged(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master M   origin/master
+  master M   origin/master 0 seconds ago Add files
 `)
 }
 
@@ -198,7 +198,7 @@ func TestRemoteNotPushed(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  master  ↑  origin/master
+  master  ↑  origin/master 0 seconds ago Add more files
 `)
 }
 
@@ -232,7 +232,7 @@ func TestRemoteNotPushedOtherBranch(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  branch1     <none>       
+  branch1     <none>        0 seconds ago Add more files
 `)
 }
 
@@ -273,7 +273,7 @@ func TestRemoteNotPulledBranch(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `./
-  branch1     <none>       
+  branch1     <none>        0 seconds ago Add file 3
 `)
 }
 
@@ -334,8 +334,8 @@ func TestMultipleRepos(t *testing.T) {
 	want.Eq(t, exitCode, 0)
 	want.Eq(t, stderr, "")
 	want.Eq(t, stdout, `repo1/
-  branch1     <none>       
+  branch1     <none>        0 seconds ago Add more files
 repo2/
-  branch1     <none>       
+  branch1     <none>        0 seconds ago Add more files
 `)
 }


### PR DESCRIPTION
### What
Add authordate and subject.

### Why
It seems useful to not only see what branches are stale, but what the last commits and their date. This is inspired by @carolynvs's `git wip` command which is awesome: https://carolynvanslyck.com/blog/2020/12/git-wip/.